### PR TITLE
fix(rss): filter out posts without `published: true`

### DIFF
--- a/src/server/routes/rss.xml.ts
+++ b/src/server/routes/rss.xml.ts
@@ -33,6 +33,7 @@ async function generateRssFeed() {
         attributes: fm(fileContents).attributes as BlogPost,
       };
     })
+    .filter(({ attributes }) => attributes.published)
     .sort((a1, a2) =>
       // eslint-disable-next-line @typescript-eslint/no-explicit-any
       (a1.attributes as any).date > (a2.attributes as any).date ? -1 : 1,


### PR DESCRIPTION
# Changes

- [x] Prevent content that is not published from being included in the RSS feed

Closes #157.