### PR TITLE
feat(blog): add pagination to blog list

### DIFF
--- a/src/app/components/paginator/paginator.component.ts
+++ b/src/app/components/paginator/paginator.component.ts
@@ -88,10 +88,7 @@ export class PaginatorComponent implements OnInit {
   }
 
   public changePage(page: number): void {
-    if (this.currentPage !== page) {
-      this.currentPage = page;
-      this.pageChanged.emit(this.currentPage);
-    }
+    this.currentPage = page;
 
     // Update the query parameter
     this.router.navigate([], {

--- a/src/app/components/paginator/paginator.component.ts
+++ b/src/app/components/paginator/paginator.component.ts
@@ -1,0 +1,96 @@
+import { NgFor, NgIf } from '@angular/common';
+import {
+  Component,
+  EventEmitter,
+  Input,
+  OnInit,
+  Output,
+  inject,
+} from '@angular/core';
+import { ActivatedRoute, Router } from '@angular/router';
+
+@Component({
+  selector: 'app-paginator',
+  standalone: true,
+  imports: [NgFor, NgIf],
+  template: `
+    <nav aria-label="Page navigation">
+      <ul>
+        <li [class.disabled]="currentPage === 1">
+          <a (click)="previousPage()">Previous</a>
+        </li>
+        <li *ngFor="let page of getPagesArray(); let i = index">
+          <a (click)="changePage(i + 1)">{{ i + 1 }}</a>
+        </li>
+        <li [class.disabled]="currentPage === totalPages">
+          <a (click)="nextPage()">Next</a>
+        </li>
+      </ul>
+    </nav>
+  `,
+})
+export class PaginatorComponent implements OnInit {
+  @Input() itemsPerPage = 10;
+  @Input() totalItems = 0;
+
+  @Output() pageChanged = new EventEmitter<number>();
+
+  public currentPage = 1;
+
+  private route = inject(ActivatedRoute);
+  private router = inject(Router);
+
+  public get totalPages(): number {
+    return Math.ceil(this.totalItems / this.itemsPerPage);
+  }
+
+  ngOnInit() {
+    this.addRouteListener();
+  }
+
+  public changePage(page: number): void {
+    if (this.currentPage !== page) {
+      this.currentPage = page;
+      this.pageChanged.emit(this.currentPage);
+    }
+
+    // Update the query parameter
+    this.router.navigate([], {
+      relativeTo: this.route,
+      queryParams: { page: this.currentPage },
+      queryParamsHandling: 'merge',
+    });
+  }
+
+  public getPagesArray(): number[] {
+    return Array.from({ length: this.totalPages }, (_, index) => index + 1);
+  }
+
+  public nextPage(): void {
+    if (this.currentPage < this.totalPages) {
+      this.changePage(this.currentPage + 1);
+    }
+  }
+
+  public previousPage(): void {
+    if (this.currentPage > 1) {
+      this.changePage(this.currentPage - 1);
+    }
+  }
+
+  private addRouteListener(): void {
+    this.route.queryParamMap.subscribe((params) => {
+      const page = params.get('page');
+      if (page) {
+        this.currentPage = parseInt(page, 10);
+        this.pageChanged.emit(this.currentPage);
+      } else {
+        this.setPageOnBareRoute();
+      }
+    });
+  }
+
+  private setPageOnBareRoute(): void {
+    this.changePage(this.currentPage);
+  }
+}

--- a/src/app/components/paginator/paginator.component.ts
+++ b/src/app/components/paginator/paginator.component.ts
@@ -121,12 +121,12 @@ export class PaginatorComponent implements OnInit {
         this.currentPage = parseInt(page, 10);
         this.pageChanged.emit(this.currentPage);
       } else {
-        this.setPageOnBareRoute();
+        this.setPageQueryParamOnBareRoute();
       }
     });
   }
 
-  private setPageOnBareRoute(): void {
+  private setPageQueryParamOnBareRoute(): void {
     this.changePage(this.currentPage);
   }
 }

--- a/src/app/components/paginator/paginator.component.ts
+++ b/src/app/components/paginator/paginator.component.ts
@@ -21,13 +21,15 @@ import { ActivatedRoute, Router } from '@angular/router';
       <a
         class="inline-flex h-8 w-8 items-center justify-center cursor-pointer rounded border border-gray-300 bg-white text-neutral-900 dark:border-neutral-400 dark:bg-neutral-900 dark:text-white rtl:rotate-180"
         (click)="previousPage()"
+        (keypress)="previousPage()"
+        tabindex="0"
       >
         <span class="sr-only">Next Page</span>
         <svg
-          xmlns="http://www.w3.org/2000/svg"
           class="h-3 w-3"
-          viewBox="0 0 20 20"
           fill="currentColor"
+          viewBox="0 0 20 20"
+          xmlns="http://www.w3.org/2000/svg"
         >
           <path
             fill-rule="evenodd"
@@ -46,13 +48,15 @@ import { ActivatedRoute, Router } from '@angular/router';
       <a
         class="inline-flex h-8 w-8 items-center justify-center cursor-pointer rounded border border-gray-300 bg-white text-neutral-900 dark:border-neutral-400 dark:bg-neutral-900 dark:text-white rtl:rotate-180"
         (click)="nextPage()"
+        (keypress)="nextPage()"
+        tabindex="0"
       >
         <span class="sr-only">Next Page</span>
         <svg
-          xmlns="http://www.w3.org/2000/svg"
           class="h-3 w-3"
           viewBox="0 0 20 20"
           fill="currentColor"
+          xmlns="http://www.w3.org/2000/svg"
         >
           <path
             fill-rule="evenodd"

--- a/src/app/components/paginator/paginator.component.ts
+++ b/src/app/components/paginator/paginator.component.ts
@@ -14,18 +14,53 @@ import { ActivatedRoute, Router } from '@angular/router';
   standalone: true,
   imports: [NgFor, NgIf],
   template: `
-    <nav aria-label="Page navigation">
-      <ul>
-        <li [class.disabled]="currentPage === 1">
-          <a (click)="previousPage()">Previous</a>
-        </li>
-        <li *ngFor="let page of getPagesArray(); let i = index">
-          <a (click)="changePage(i + 1)">{{ i + 1 }}</a>
-        </li>
-        <li [class.disabled]="currentPage === totalPages">
-          <a (click)="nextPage()">Next</a>
-        </li>
-      </ul>
+    <nav
+      aria-label="Page navigation"
+      class="flex items-center justify-center gap-3 mb-3"
+    >
+      <a
+        class="inline-flex h-8 w-8 items-center justify-center cursor-pointer rounded border border-gray-300 bg-white text-neutral-900 dark:border-neutral-400 dark:bg-neutral-900 dark:text-white rtl:rotate-180"
+        (click)="previousPage()"
+      >
+        <span class="sr-only">Next Page</span>
+        <svg
+          xmlns="http://www.w3.org/2000/svg"
+          class="h-3 w-3"
+          viewBox="0 0 20 20"
+          fill="currentColor"
+        >
+          <path
+            fill-rule="evenodd"
+            d="M12.707 5.293a1 1 0 010 1.414L9.414 10l3.293 3.293a1 1 0 01-1.414 1.414l-4-4a1 1 0 010-1.414l4-4a1 1 0 011.414 0z"
+            clip-rule="evenodd"
+          />
+        </svg>
+      </a>
+
+      <p class="text-xs">
+        {{ currentPage }}
+        <span class="mx-0.25">/</span>
+        {{ totalPages }}
+      </p>
+
+      <a
+        class="inline-flex h-8 w-8 items-center justify-center cursor-pointer rounded border border-gray-300 bg-white text-neutral-900 dark:border-neutral-400 dark:bg-neutral-900 dark:text-white rtl:rotate-180"
+        (click)="nextPage()"
+      >
+        <span class="sr-only">Next Page</span>
+        <svg
+          xmlns="http://www.w3.org/2000/svg"
+          class="h-3 w-3"
+          viewBox="0 0 20 20"
+          fill="currentColor"
+        >
+          <path
+            fill-rule="evenodd"
+            d="M7.293 14.707a1 1 0 010-1.414L10.586 10 7.293 6.707a1 1 0 011.414-1.414l4 4a1 1 0 010 1.414l-4 4a1 1 0 01-1.414 0z"
+            clip-rule="evenodd"
+          />
+        </svg>
+      </a>
     </nav>
   `,
 })

--- a/src/app/pages/blog/index.page.ts
+++ b/src/app/pages/blog/index.page.ts
@@ -5,6 +5,7 @@ import { MetaDefinition } from '@angular/platform-browser';
 import { ContentFile, injectContentFiles } from '@analogjs/content';
 import { RouteMeta } from '@analogjs/router';
 
+import { ArchiveComponent } from '@components/archive/archive.component';
 import { BlogCardComponent } from '@components/blog-card/blog-card.component';
 import { PaginatorComponent } from '@components/paginator/paginator.component';
 import { siteName } from '@constants/site-name';
@@ -41,6 +42,7 @@ export const metaTagList: MetaDefinition[] = [
   selector: 'app-blog-index',
   standalone: true,
   imports: [
+    ArchiveComponent,
     BlogCardComponent,
     NgFor,
     NgIf,
@@ -70,6 +72,7 @@ export const metaTagList: MetaDefinition[] = [
               </li></ng-template
             >
           </ul>
+          <app-archive [posts]="posts" />
         </div>
       </div>
     </div>

--- a/src/app/pages/blog/index.page.ts
+++ b/src/app/pages/blog/index.page.ts
@@ -80,7 +80,7 @@ export const metaTagList: MetaDefinition[] = [
 })
 export default class IndexPageComponent {
   public displayedPosts: ContentFile<BlogPost>[] = [];
-  public itemsPerPage = 10;
+  public itemsPerPage = 5;
   public posts = injectContentFiles<BlogPost>((mdFile) =>
     mdFile.filename.includes('/src/content/posts'),
   )


### PR DESCRIPTION
# Changes

- [x] Add a pagination component to the blog list
- [x] Use query params to hydrate the view
- [x] Set `?page=1` if the route is the bare `/blog`
- [x] Bind the archive component to the blog list now that the page doesn't show all posts

Closes #172.