### PR TITLE
feat(components): redo navigation buttons as styled `a` links

### DIFF
--- a/src/app/components/paginator/paginator.component.ts
+++ b/src/app/components/paginator/paginator.component.ts
@@ -7,12 +7,12 @@ import {
   Output,
   inject,
 } from '@angular/core';
-import { ActivatedRoute, Router } from '@angular/router';
+import { ActivatedRoute, Router, RouterLink } from '@angular/router';
 
 @Component({
   selector: 'app-paginator',
   standalone: true,
-  imports: [NgFor, NgIf],
+  imports: [NgFor, NgIf, RouterLink],
   template: `
     <nav
       aria-label="Page navigation"
@@ -20,8 +20,9 @@ import { ActivatedRoute, Router } from '@angular/router';
     >
       <a
         class="inline-flex h-8 w-8 items-center justify-center cursor-pointer rounded border border-gray-300 bg-white text-neutral-900 dark:border-neutral-400 dark:bg-neutral-900 dark:text-white rtl:rotate-180"
-        (click)="previousPage()"
-        (keypress)="previousPage()"
+        [routerLink]="'/blog'"
+        [queryParams]="{ page: previousPage() }"
+        queryParamsHandling="merge"
         tabindex="0"
       >
         <span class="sr-only">Next Page</span>
@@ -47,8 +48,9 @@ import { ActivatedRoute, Router } from '@angular/router';
 
       <a
         class="inline-flex h-8 w-8 items-center justify-center cursor-pointer rounded border border-gray-300 bg-white text-neutral-900 dark:border-neutral-400 dark:bg-neutral-900 dark:text-white rtl:rotate-180"
-        (click)="nextPage()"
-        (keypress)="nextPage()"
+        [routerLink]="'/blog'"
+        [queryParams]="{ page: nextPage() }"
+        queryParamsHandling="merge"
         tabindex="0"
       >
         <span class="sr-only">Next Page</span>
@@ -92,26 +94,19 @@ export class PaginatorComponent implements OnInit {
 
     // Update the query parameter
     this.router.navigate([], {
-      relativeTo: this.route,
       queryParams: { page: this.currentPage },
       queryParamsHandling: 'merge',
     });
   }
 
-  public getPagesArray(): number[] {
-    return Array.from({ length: this.totalPages }, (_, index) => index + 1);
+  public nextPage(): number {
+    return this.currentPage < this.totalPages
+      ? this.currentPage + 1
+      : this.currentPage;
   }
 
-  public nextPage(): void {
-    if (this.currentPage < this.totalPages) {
-      this.changePage(this.currentPage + 1);
-    }
-  }
-
-  public previousPage(): void {
-    if (this.currentPage > 1) {
-      this.changePage(this.currentPage - 1);
-    }
+  public previousPage(): number {
+    return this.currentPage > 1 ? this.currentPage - 1 : this.currentPage;
   }
 
   private addRouteListener(): void {
@@ -121,12 +116,8 @@ export class PaginatorComponent implements OnInit {
         this.currentPage = parseInt(page, 10);
         this.pageChanged.emit(this.currentPage);
       } else {
-        this.setPageQueryParamOnBareRoute();
+        this.changePage(1);
       }
     });
-  }
-
-  private setPageQueryParamOnBareRoute(): void {
-    this.changePage(this.currentPage);
   }
 }

--- a/src/app/components/pill/pill.component.spec.ts
+++ b/src/app/components/pill/pill.component.spec.ts
@@ -6,8 +6,7 @@ import { RouterTestingModule } from '@angular/router/testing';
 import PillComponent from './pill.component';
 
 @Component({
-  template:
-    '<app-pill [label]="label" [route]="route" [slug]="slug" />',
+  template: '<app-pill [label]="label" [route]="route" [slug]="slug" />',
 })
 class TestHostComponent {
   label: string | undefined;
@@ -38,7 +37,7 @@ describe('PillComponent', () => {
     testHost.label = label;
     fixture.detectChanges();
 
-    const buttonElement = fixture.debugElement.query(By.css('button'));
+    const buttonElement = fixture.debugElement.query(By.css('a'));
     const buttonInnerText = buttonElement.nativeElement.textContent.trim();
 
     expect(buttonInnerText).toBe('Sample Label');

--- a/src/app/components/pill/pill.component.ts
+++ b/src/app/components/pill/pill.component.ts
@@ -7,12 +7,12 @@ import { RouterLink } from '@angular/router';
   standalone: true,
   imports: [RouterLink, TitleCasePipe],
   template: `
-    <button
-      class="my-1 py-1 px-3 no-underline rounded-full bg-neutral-500 dark:bg-neutral-700 text-white font-semibold text-xs hover:text-white hover:bg-neutral-700 dark:hover:bg-neutral-500"
+    <a
+      class="my-1 py-1 px-3 no-underline rounded-full inline-block bg-neutral-500 dark:bg-neutral-700 text-white font-semibold text-xs hover:text-white hover:bg-neutral-700 dark:hover:bg-neutral-500"
       [routerLink]="[route, slug]"
     >
       {{ label | titlecase }}
-    </button>
+    </a>
   `,
 })
 export default class PillComponent {

--- a/src/app/components/post-navigation/post-navigation.component.ts
+++ b/src/app/components/post-navigation/post-navigation.component.ts
@@ -14,7 +14,7 @@ import { getYear } from '@utils/get-year';
   imports: [NgFor, NgIf, RouterLink],
   template: `
     <div class="flex justify-between text-sm mt-2 gap-2">
-      <button
+      <a
         *ngIf="prevPost"
         [routerLink]="[
           '/blog',
@@ -25,13 +25,12 @@ import { getYear } from '@utils/get-year';
         attr.alt="Click to go to the previous post: {{
           prevPost.attributes.title
         }}"
-        type="button"
-        class="inline-flex focus:outline-none bg-indigo-200 hover:bg-indigo-300 focus:ring-2 focus:ring-indigo-300 font-medium rounded-lg text-sm px-3 py-1 mr-2 mb-2 dark:bg-indigo-600 dark:hover:bg-indigo-700 dark:focus:ring-indigo-800 truncate"
+        class="hover:text-inherit no-underline inline-flex bg-indigo-200 hover:bg-indigo-300 focus:ring-2 focus:ring-indigo-300 font-medium rounded-lg text-sm px-3 py-1 mr-2 mb-2 dark:bg-indigo-600 dark:hover:bg-indigo-700 dark:focus:ring-indigo-800 truncate"
       >
         <span>&laquo; &nbsp;</span
         ><span class="truncate">{{ prevPost.attributes.title }}</span>
-      </button>
-      <button
+      </a>
+      <a
         *ngIf="nextPost"
         [routerLink]="[
           '/blog',
@@ -40,12 +39,11 @@ import { getYear } from '@utils/get-year';
           nextPost.slug
         ]"
         attr.alt="Click to go to the next post: {{ nextPost.attributes.title }}"
-        type="button"
-        class="inline-flex ml-auto focus:outline-none bg-indigo-200 hover:bg-indigo-300 focus:ring-2 focus:ring-indigo-300 font-medium rounded-lg text-sm px-3 py-1 mr-2 mb-2 dark:bg-indigo-600 dark:hover:bg-indigo-700 dark:focus:ring-indigo-800 truncate"
+        class="hover:text-inherit no-underline inline-flex ml-auto bg-indigo-200 hover:bg-indigo-300 focus:ring-2 focus:ring-indigo-300 font-medium rounded-lg text-sm px-3 py-1 mr-2 mb-2 dark:bg-indigo-600 dark:hover:bg-indigo-700 dark:focus:ring-indigo-800 truncate"
       >
         <span class="truncate">{{ nextPost.attributes.title }}</span
         ><span>&nbsp; &raquo;</span>
-      </button>
+      </a>
     </div>
   `,
 })


### PR DESCRIPTION
# Changes

- [x] Use styled `a` for navigation links

Closes #174.