### PR TITLE
refactor(app): remove default from reusable component classes

### DIFF
--- a/src/app/app.component.ts
+++ b/src/app/app.component.ts
@@ -9,8 +9,8 @@ import {
 
 import { filter, map, mergeMap } from 'rxjs';
 
-import FooterComponent from '@components/footer/footer.component';
-import HeaderComponent from '@components/header/header.component';
+import { FooterComponent } from '@components/footer/footer.component';
+import { HeaderComponent } from '@components/header/header.component';
 import { siteName } from '@constants/site-name';
 import { url } from '@constants/site-url';
 import { MetadataService } from '@services/metadata.service';

--- a/src/app/components/blog-card/blog-card.component.ts
+++ b/src/app/components/blog-card/blog-card.component.ts
@@ -14,7 +14,7 @@ import { RouterLink } from '@angular/router';
 import { ContentFile } from '@analogjs/content';
 import { debounceTime, Observable } from 'rxjs';
 
-import PillComponent from '@components/pill/pill.component';
+import { PillComponent } from '@components/pill/pill.component';
 import { SkeletonCardComponent } from '@components/skeleton-card/skeleton-card.component';
 import { smallBreakpointSize } from '@constants/breakpoint-size';
 import { ReplaceBrokenImageDirective } from '@directives/replace-broken-image.directive';

--- a/src/app/components/footer/footer.component.spec.ts
+++ b/src/app/components/footer/footer.component.spec.ts
@@ -2,7 +2,7 @@ import { Component } from '@angular/core';
 import { By } from '@angular/platform-browser';
 import { ComponentFixture, TestBed } from '@angular/core/testing';
 
-import FooterComponent from './footer.component';
+import { FooterComponent } from './footer.component';
 
 @Component({
   template: '<app-footer />',

--- a/src/app/components/footer/footer.component.ts
+++ b/src/app/components/footer/footer.component.ts
@@ -52,7 +52,7 @@ import { Navigation } from '@models/navigation';
     </footer>
   `,
 })
-export default class FooterComponent {
+export class FooterComponent {
   public readonly currentYear = new Date().getFullYear();
   public linkList: Navigation[] = [
     {

--- a/src/app/components/header/header.component.spec.ts
+++ b/src/app/components/header/header.component.spec.ts
@@ -3,7 +3,7 @@ import { ComponentFixture, TestBed } from '@angular/core/testing';
 import { By } from '@angular/platform-browser';
 import { provideRouter } from '@angular/router';
 
-import HeaderComponent from './header.component';
+import { HeaderComponent } from './header.component';
 
 @Component({
   template: '<app-header />',

--- a/src/app/components/header/header.component.ts
+++ b/src/app/components/header/header.component.ts
@@ -121,7 +121,7 @@ import { ThemeService } from '@services/theme.service';
     </nav>
   `,
 })
-export default class HeaderComponent implements OnInit {
+export class HeaderComponent implements OnInit {
   public form: FormGroup = new FormGroup({});
   public linkList: Navigation[] = [
     {

--- a/src/app/components/masonry-grid/masonry-grid.component.ts
+++ b/src/app/components/masonry-grid/masonry-grid.component.ts
@@ -3,8 +3,8 @@ import { Component, inject, signal, WritableSignal } from '@angular/core';
 
 import { tap } from 'rxjs';
 
-import ImageInfoPopoverContentComponent from '@components/popover/image-info-popover-content.component';
-import PopoverComponent from '@components/popover/popover.component';
+import { ImageInfoPopoverContentComponent } from '@components/popover/image-info-popover-content.component';
+import { PopoverComponent } from '@components/popover/popover.component';
 import { SpinnerComponent } from '@components/spinner/spinner.component';
 import { flickr } from '@constants/flickr';
 import { FlickrService } from '@services/api/flickr.service';

--- a/src/app/components/pill/pill.component.spec.ts
+++ b/src/app/components/pill/pill.component.spec.ts
@@ -3,7 +3,7 @@ import { ComponentFixture, TestBed } from '@angular/core/testing';
 import { By } from '@angular/platform-browser';
 import { provideRouter } from '@angular/router';
 
-import PillComponent from './pill.component';
+import { PillComponent } from './pill.component';
 
 @Component({
   template: '<app-pill [label]="label" [route]="route" [slug]="slug" />',

--- a/src/app/components/pill/pill.component.ts
+++ b/src/app/components/pill/pill.component.ts
@@ -15,7 +15,7 @@ import { RouterLink } from '@angular/router';
     </a>
   `,
 })
-export default class PillComponent {
+export class PillComponent {
   @Input() public label!: string | undefined;
   @Input() public route!: string | undefined;
   @Input() public slug!: string | undefined;

--- a/src/app/components/popover/image-info-popover-content.component.spec.ts
+++ b/src/app/components/popover/image-info-popover-content.component.spec.ts
@@ -2,7 +2,7 @@ import { ComponentFixture, TestBed } from '@angular/core/testing';
 import { Component, DebugElement } from '@angular/core';
 import { By } from '@angular/platform-browser';
 
-import ImageInfoPopoverContentComponent from './image-info-popover-content.component';
+import { ImageInfoPopoverContentComponent } from './image-info-popover-content.component';
 
 @Component({
   template: `

--- a/src/app/components/popover/image-info-popover-content.component.ts
+++ b/src/app/components/popover/image-info-popover-content.component.ts
@@ -16,7 +16,7 @@ import { Component, Input } from '@angular/core';
     </div>
   `,
 })
-export default class ImageInfoPopoverContentComponent {
+export class ImageInfoPopoverContentComponent {
   @Input() public cover_image_author!: string | undefined;
   @Input() public cover_image_source!: string | undefined;
   @Input() public cover_image_title!: string | undefined;

--- a/src/app/components/popover/popover.component.spec.ts
+++ b/src/app/components/popover/popover.component.spec.ts
@@ -1,7 +1,7 @@
 import { ComponentFixture, TestBed } from '@angular/core/testing';
 import { Renderer2, Type } from '@angular/core';
 
-import PopoverComponent from './popover.component';
+import { PopoverComponent } from './popover.component';
 
 describe('PopoverComponent', () => {
   let popoverComponent: PopoverComponent;

--- a/src/app/components/popover/popover.component.ts
+++ b/src/app/components/popover/popover.component.ts
@@ -35,7 +35,7 @@ import {
   `,
   styleUrls: ['./popover.component.scss'],
 })
-export default class PopoverComponent implements OnInit, OnDestroy {
+export class PopoverComponent implements OnInit, OnDestroy {
   @Input() public altText!: string | undefined;
   @Input() public icon!: string | undefined;
 

--- a/src/app/pages/blog/[year].[month].[slug].page.ts
+++ b/src/app/pages/blog/[year].[month].[slug].page.ts
@@ -25,9 +25,9 @@ import {
 import { map, switchMap, tap } from 'rxjs';
 
 import { ArchiveComponent } from '@components/archive/archive.component';
-import PillComponent from '@components/pill/pill.component';
-import ImageInfoPopoverContentComponent from '@components/popover/image-info-popover-content.component';
-import PopoverComponent from '@components/popover/popover.component';
+import { PillComponent } from '@components/pill/pill.component';
+import { ImageInfoPopoverContentComponent } from '@components/popover/image-info-popover-content.component';
+import { PopoverComponent } from '@components/popover/popover.component';
 import { PostNavigationComponent } from '@components/post-navigation/post-navigation.component';
 import { siteName } from '@constants/site-name';
 import { ReplaceBrokenImageDirective } from '@directives/replace-broken-image.directive';

--- a/src/app/pages/category/index.page.ts
+++ b/src/app/pages/category/index.page.ts
@@ -6,7 +6,7 @@ import { RouterLink } from '@angular/router';
 import { ContentFile, injectContentFiles } from '@analogjs/content';
 import { RouteMeta } from '@analogjs/router';
 
-import PillComponent from '@components/pill/pill.component';
+import { PillComponent } from '@components/pill/pill.component';
 import { siteName } from '@constants/site-name';
 import { BlogPost } from '@models/post';
 import { MetadataService } from '@services/metadata.service';

--- a/src/app/pages/tag/index.page.ts
+++ b/src/app/pages/tag/index.page.ts
@@ -6,7 +6,7 @@ import { RouterLink } from '@angular/router';
 import { ContentFile, injectContentFiles } from '@analogjs/content';
 import { RouteMeta } from '@analogjs/router';
 
-import PillComponent from '@components/pill/pill.component';
+import { PillComponent } from '@components/pill/pill.component';
 import { siteName } from '@constants/site-name';
 import { BlogPost } from '@models/post';
 import { Tag } from '@models/tag';


### PR DESCRIPTION
# Changes

- [x] Replace default classes for reusable components
  - Note: It appears that Analog requires page components to be default

Closes #229.