### PR TITLE
feat(components): extend object fit cover

### DIFF
--- a/src/app/components/blog-card/blog-card.component.ts
+++ b/src/app/components/blog-card/blog-card.component.ts
@@ -85,25 +85,33 @@ import { getMonth } from '@utils/get-month';
         />
         <a [routerLink]="['/blog', year, month, post.slug]">
           <ng-container *ngIf="isLCP; else nonPriority">
-            <img
-              [src]="post.attributes.cover_image || ''"
-              [alt]="post.attributes.cover_image_title ?? 'Post Cover Image'"
-              [ngStyle]="{ visibility: showSkeleton() ? 'hidden' : 'visible' }"
-              (load)="onLoad()"
-              appReplaceBrokenImage
-              class="sm:max-w-xs rounded-md sm:w-full sm:h-full sm:object-cover sm:object-center"
-              priority
-            />
+            <span class="flex aspect-[1/0.65]">
+              <img
+                [src]="post.attributes.cover_image || ''"
+                [alt]="post.attributes.cover_image_title ?? 'Post Cover Image'"
+                [ngStyle]="{
+                  visibility: showSkeleton() ? 'hidden' : 'visible'
+                }"
+                (load)="onLoad()"
+                appReplaceBrokenImage
+                class="sm:max-w-xs rounded-md w-full h-full object-cover object-center"
+                priority
+              />
+            </span>
           </ng-container>
           <ng-template #nonPriority>
-            <img
-              [src]="post.attributes.cover_image || ''"
-              [alt]="post.attributes.cover_image_title ?? 'Post Cover Image'"
-              [ngStyle]="{ visibility: showSkeleton() ? 'hidden' : 'visible' }"
-              (load)="onLoad()"
-              appReplaceBrokenImage
-              class="sm:max-w-xs rounded-md sm:w-full sm:h-full sm:object-cover sm:object-center"
-            />
+            <span class="flex aspect-[1/0.65]">
+              <img
+                [src]="post.attributes.cover_image || ''"
+                [alt]="post.attributes.cover_image_title ?? 'Post Cover Image'"
+                [ngStyle]="{
+                  visibility: showSkeleton() ? 'hidden' : 'visible'
+                }"
+                (load)="onLoad()"
+                appReplaceBrokenImage
+                class="sm:max-w-xs rounded-md w-full h-full object-cover object-center"
+              />
+            </span>
           </ng-template>
         </a>
       </div>

--- a/src/app/components/photo-album/photo-album.component.ts
+++ b/src/app/components/photo-album/photo-album.component.ts
@@ -39,6 +39,7 @@ import { ScreenSizeService } from '@services/screen-size.service';
       />
       <a
         [href]="flickr.albumUrl + '/' + photo.id"
+        class="flex aspect-[1/0.65]"
         target="_blank"
         rel="noopener"
       >
@@ -57,7 +58,7 @@ import { ScreenSizeService } from '@services/screen-size.service';
           (load)="onLoad()"
           alt=""
           appReplaceBrokenImage
-          class="w-full rounded-md"
+          class="w-full rounded-md object-cover"
           height="491"
           width="736"
         />


### PR DESCRIPTION
# Changes

- [x] Add `object-fit: cover` to recent photo album list on homepage
- [x] Add `object-fit: cover` to mobile size of blog cards
- [x] Use `aspect-ratio` property to constraint image height correctly at different sizes

Closes #240.