### PR TITLE
fix(photo-album): use better image size from flickr for album covers

### DIFF
--- a/src/app/components/photo-album/photo-album.component.ts
+++ b/src/app/components/photo-album/photo-album.component.ts
@@ -52,7 +52,7 @@ import { ScreenSizeService } from '@services/screen-size.service';
             photo.primary +
             '_' +
             photo.secret +
-            '_w.jpg'
+            '_c.jpg'
           "
           [ngStyle]="{ visibility: showSkeleton() ? 'hidden' : 'visible' }"
           (load)="onLoad()"


### PR DESCRIPTION
# Changes

- [x] Use correct flickr image suffix to get 800px width images

Closes #249.