### PR TITLE
fix(photo-album): improve responsive design for safari

### DIFF
--- a/src/app/components/photo-album/photo-album.component.ts
+++ b/src/app/components/photo-album/photo-album.component.ts
@@ -58,7 +58,7 @@ import { ScreenSizeService } from '@services/screen-size.service';
           (load)="onLoad()"
           alt=""
           appReplaceBrokenImage
-          class="w-full rounded-md object-cover"
+          class="w-full h-full rounded-md object-cover"
           height="491"
           width="736"
         />


### PR DESCRIPTION
# Fixes

- [x] Set an explicit height for element with `object-fit: cover` so that Safari applies `object-fit: cover` correctly

Closes #261.