### PR TITLE
feat, refactor(components, pages): improve loading and error ux for flickr photos

### DIFF
--- a/src/app/components/recent-photo-albums/recent-photo-albums.component.ts
+++ b/src/app/components/recent-photo-albums/recent-photo-albums.component.ts
@@ -1,7 +1,7 @@
 import { AsyncPipe, NgFor, NgIf } from '@angular/common';
 import { Component, inject, signal, WritableSignal } from '@angular/core';
 
-import { tap } from 'rxjs';
+import { catchError, of, tap } from 'rxjs';
 
 import { PhotoAlbumComponent } from '@components/photo-album/photo-album.component';
 import { SpinnerComponent } from '@components/spinner/spinner.component';
@@ -13,7 +13,7 @@ import { FlickrService } from '@services/api/flickr.service';
   imports: [AsyncPipe, NgFor, NgIf, PhotoAlbumComponent, SpinnerComponent],
   template: `
     <app-spinner *ngIf="loading()" />
-    <div *ngIf="photos$ | async as photos">
+    <div *ngIf="photos$ | async as photos; else emptyResponse">
       <h2 class="text-xl">Latest Photo Albums:</h2>
       <div class="flex gap-4 flex-wrap justify-center xl:justify-normal">
         <ng-container *ngFor="let photo of photos">
@@ -21,6 +21,11 @@ import { FlickrService } from '@services/api/flickr.service';
         </ng-container>
       </div>
     </div>
+    <ng-template #emptyResponse>
+      <div *ngIf="!loading()">
+        No photos are available from Flickr. Try again later?
+      </div>
+    </ng-template>
   `,
 })
 export class RecentPhotoAlbumsComponent {
@@ -28,7 +33,12 @@ export class RecentPhotoAlbumsComponent {
 
   public loading: WritableSignal<boolean> = signal(true);
 
-  public photos$ = this.flickrService
-    .getRecentPhotosets()
-    .pipe(tap(() => this.loading.set(false)));
+  public photos$ = this.flickrService.getRecentPhotosets().pipe(
+    tap(() => this.loading.set(false)),
+    catchError(() => {
+      this.loading.set(false);
+
+      return of(null);
+    }),
+  );
 }

--- a/src/app/pages/photos/index.page.ts
+++ b/src/app/pages/photos/index.page.ts
@@ -65,9 +65,9 @@ export const metaTagList: MetaDefinition[] = [
             >
               {{ profile?.description?._content }}
             </div>
-            <app-masonry-grid />
           </div>
         </div>
+        <app-masonry-grid />
       </div>
     </div>
   `,

--- a/src/app/pages/photos/index.page.ts
+++ b/src/app/pages/photos/index.page.ts
@@ -1,5 +1,5 @@
 import { AsyncPipe, NgIf } from '@angular/common';
-import { Component, inject, signal, WritableSignal } from '@angular/core';
+import { Component, inject } from '@angular/core';
 import { MetaDefinition } from '@angular/platform-browser';
 
 import { RouteMeta } from '@analogjs/router';
@@ -73,7 +73,6 @@ export default class IndexPageComponent {
   private flickrService = inject(FlickrService);
   private metadataService = inject(MetadataService);
 
-  public loading: WritableSignal<boolean> = signal(true);
   public profile$ = this.flickrService.getProfile();
 
   constructor() {

--- a/src/app/pages/photos/index.page.ts
+++ b/src/app/pages/photos/index.page.ts
@@ -1,12 +1,10 @@
-import { AsyncPipe, JsonPipe, NgIf } from '@angular/common';
+import { AsyncPipe, NgIf } from '@angular/common';
 import { Component, inject, signal, WritableSignal } from '@angular/core';
 import { MetaDefinition } from '@angular/platform-browser';
 
 import { RouteMeta } from '@analogjs/router';
-import { catchError, of, tap } from 'rxjs';
 
 import { MasonryGridComponent } from '@components/masonry-grid/masonry-grid.component';
-import { SpinnerComponent } from '@components/spinner/spinner.component';
 import { siteName } from '@constants/site-name';
 import { FlickrService } from '@services/api/flickr.service';
 import { MetadataService } from '@services/metadata.service';
@@ -42,7 +40,7 @@ export const metaTagList: MetaDefinition[] = [
 @Component({
   selector: 'app-photos-index',
   standalone: true,
-  imports: [AsyncPipe, NgIf, MasonryGridComponent, SpinnerComponent, JsonPipe],
+  imports: [AsyncPipe, NgIf, MasonryGridComponent],
   template: `
     <div class="md:max-w md:mx-auto md:flex md:flex-col md:items-center">
       <div class="md:w-[48rem] p-4">
@@ -57,7 +55,6 @@ export const metaTagList: MetaDefinition[] = [
               >Flickr</a
             >.
           </div>
-          <app-spinner *ngIf="loading()" class="py-3 block" />
           <div *ngIf="profile$ | async as profile">
             <div
               *ngIf="profile?.description?._content"
@@ -77,14 +74,7 @@ export default class IndexPageComponent {
   private metadataService = inject(MetadataService);
 
   public loading: WritableSignal<boolean> = signal(true);
-  public profile$ = this.flickrService.getProfile().pipe(
-    tap(() => this.loading.set(false)),
-    catchError((error) => {
-      this.loading.set(false);
-
-      return of(error);
-    }),
-  );
+  public profile$ = this.flickrService.getProfile();
 
   constructor() {
     this.metadataService.setPageURLMetaTitle(pageTitle.title);


### PR DESCRIPTION
# Changes

- [x] Add a loading state to flickr photos
- [x] Tag loading state to api calls
- [x] Set loading state to false on success and error
- [x] Add spinner to recent photo albums on homepage
- [x] Set error message to load when response is empty and loading is false
- [x] Move error message from photos index to masonry-grid

Closes #266.