### PR TITLE
feat(components, pages): extend skeleton cards

### DIFF
--- a/src/app/components/photo-album/photo-album.component.ts
+++ b/src/app/components/photo-album/photo-album.component.ts
@@ -1,22 +1,10 @@
 import { NgIf, NgOptimizedImage, NgStyle } from '@angular/common';
-import {
-  Component,
-  DestroyRef,
-  inject,
-  Input,
-  OnInit,
-  signal,
-  WritableSignal,
-} from '@angular/core';
-import { takeUntilDestroyed } from '@angular/core/rxjs-interop';
-
-import { Observable, debounceTime } from 'rxjs';
+import { Component, Input, signal, WritableSignal } from '@angular/core';
 
 import { SkeletonCardComponent } from '@components/skeleton-card/skeleton-card.component';
 import { flickr } from '@constants/flickr';
 import { ReplaceBrokenImageDirective } from '@directives/replace-broken-image.directive';
 import { PhotosetListItem } from '@models/flickr';
-import { ScreenSizeService } from '@services/screen-size.service';
 
 @Component({
   selector: 'app-photo-album',
@@ -77,26 +65,11 @@ import { ScreenSizeService } from '@services/screen-size.service';
     </div>
   `,
 })
-export class PhotoAlbumComponent implements OnInit {
+export class PhotoAlbumComponent {
   @Input() public photo!: PhotosetListItem;
 
   public flickr = flickr;
-  public isSmallScreen: boolean = false;
-  public screenWidth$!: Observable<number>;
   public showSkeleton: WritableSignal<boolean> = signal(true);
-
-  private destroyRef = inject(DestroyRef);
-  private screenSizeService = inject(ScreenSizeService);
-
-  public ngOnInit(): void {
-    const smallScreenSize = 768;
-    this.screenWidth$ = this.screenSizeService.screenWidth;
-    this.screenWidth$
-      .pipe(debounceTime(300), takeUntilDestroyed(this.destroyRef))
-      .subscribe((width) => {
-        this.isSmallScreen = width < smallScreenSize;
-      });
-  }
 
   public onLoad(): void {
     this.showSkeleton.set(false);

--- a/src/app/components/photo-album/photo-album.component.ts
+++ b/src/app/components/photo-album/photo-album.component.ts
@@ -35,7 +35,7 @@ import { ScreenSizeService } from '@services/screen-size.service';
         class="rounded-md absolute min-w-full h-full"
         height="100%"
         maxWidth="100%"
-        [width]="isSmallScreen ? '' : '736px'"
+        width=""
       />
       <a
         [href]="flickr.albumUrl + '/' + photo.id"
@@ -44,7 +44,7 @@ import { ScreenSizeService } from '@services/screen-size.service';
         rel="noopener"
       >
         <img
-          [ngSrc]="
+          [src]="
             flickr.albumPhotoUrl +
             '/' +
             photo.server +
@@ -59,8 +59,6 @@ import { ScreenSizeService } from '@services/screen-size.service';
           alt=""
           appReplaceBrokenImage
           class="w-full h-full rounded-md object-cover"
-          height="491"
-          width="736"
         />
         <div
           class="absolute top-0 left-0 right-0 bottom-0 flex flex-col justify-end p-4"

--- a/src/app/pages/about/index.page.ts
+++ b/src/app/pages/about/index.page.ts
@@ -1,10 +1,11 @@
 import { AsyncPipe, NgIf, NgOptimizedImage } from '@angular/common';
-import { Component, inject } from '@angular/core';
+import { Component, inject, signal, WritableSignal } from '@angular/core';
 import { MetaDefinition } from '@angular/platform-browser';
 
 import { MarkdownComponent, injectContent } from '@analogjs/content';
 import { RouteMeta } from '@analogjs/router';
 
+import { SkeletonCardComponent } from '@components/skeleton-card/skeleton-card.component';
 import { siteName } from '@constants/site-name';
 import { url } from '@constants/site-url';
 import { MetadataService } from '@services/metadata.service';
@@ -38,20 +39,39 @@ export const metaTagList: MetaDefinition[] = [
 @Component({
   selector: 'app-about-index',
   standalone: true,
-  imports: [AsyncPipe, NgIf, NgOptimizedImage, MarkdownComponent],
+  imports: [
+    AsyncPipe,
+    NgIf,
+    NgOptimizedImage,
+    MarkdownComponent,
+    SkeletonCardComponent,
+  ],
   template: `
     <h1 class="sr-only">About</h1>
     <div class="md:max-w md:mx-auto md:flex md:justify-center">
       <div class="md:w-[48rem] p-4">
         <div class="flex-1">
-          <img
-            ngSrc="${url}/images/self/me.jpg"
-            class="rounded max-h-[32rem] mx-auto"
-            alt="Me in Norway"
-            priority
-            height="816"
-            width="384"
-          />
+          <div
+            class="relative mx-auto [@media(min-width:430px)]:max-h-[32rem] [@media(min-width:430px)]:w-96"
+          >
+            <app-skeleton-card
+              *ngIf="showSkeleton()"
+              class="rounded-md absolute min-w-full h-full"
+              height="100%"
+              maxWidth="100%"
+              width="100%"
+            />
+            <img
+              [ngStyle]="{
+                visibility: showSkeleton() ? 'hidden' : 'visible'
+              }"
+              (load)="onLoad()"
+              src="${url}/images/self/me.jpg"
+              class="rounded-md"
+              alt="Me in Norway"
+              priority
+            />
+          </div>
           <div *ngIf="about$ | async as about">
             <analog-markdown
               class="prose dark:prose-invert prose-code:before:hidden prose-code:after:hidden"
@@ -73,8 +93,11 @@ export const metaTagList: MetaDefinition[] = [
   `,
 })
 export default class IndexPageComponent {
+  public showSkeleton: WritableSignal<boolean> = signal(true);
   public version = version;
+
   private metadataService = inject(MetadataService);
+
   readonly about$ = injectContent<{ content: string }>({
     customFilename: 'about/about',
   });
@@ -82,5 +105,9 @@ export default class IndexPageComponent {
   constructor() {
     this.metadataService.setPageURLMetaTitle(pageTitle.title);
     this.metadataService.updateTags(metaTagList);
+  }
+
+  public onLoad(): void {
+    this.showSkeleton.set(false);
   }
 }

--- a/src/app/pages/index.page.ts
+++ b/src/app/pages/index.page.ts
@@ -1,5 +1,11 @@
-import { NgFor, NgIf } from '@angular/common';
-import { Component, OnInit, inject } from '@angular/core';
+import { NgFor, NgIf, NgStyle } from '@angular/common';
+import {
+  Component,
+  OnInit,
+  WritableSignal,
+  inject,
+  signal,
+} from '@angular/core';
 import { MetaDefinition } from '@angular/platform-browser';
 import { RouterLink } from '@angular/router';
 
@@ -8,6 +14,7 @@ import { RouteMeta } from '@analogjs/router';
 
 import { BlogCardComponent } from '@components/blog-card/blog-card.component';
 import { RecentPhotoAlbumsComponent } from '@components/recent-photo-albums/recent-photo-albums.component';
+import { SkeletonCardComponent } from '@components/skeleton-card/skeleton-card.component';
 import { siteName } from '@constants/site-name';
 import { BlogPost } from '@models/post';
 import { MetadataService } from '@services/metadata.service';
@@ -50,8 +57,10 @@ export const metaTagList: MetaDefinition[] = [
     BlogCardComponent,
     NgIf,
     NgFor,
+    NgStyle,
     RecentPhotoAlbumsComponent,
     RouterLink,
+    SkeletonCardComponent,
   ],
   template: `
     <div class="md:max-w md:mx-auto md:flex md:justify-center">
@@ -61,11 +70,26 @@ export const metaTagList: MetaDefinition[] = [
           <div
             class="flex flex-col sm:flex-row justify-evenly items-center pb-4 sm:flex-nowrap"
           >
-            <img
-              src="images/self/me-sq.jpg"
-              class="rounded-xl max-h-32 sm:max-h-36"
-              alt="Me in Norway"
-            />
+            <div
+              class="relative flex justify-center rounded-xl max-h-32 sm:max-h-36 max-w-32 sm:max-w-36"
+            >
+              <app-skeleton-card
+                *ngIf="showSkeleton()"
+                class="rounded-md absolute min-w-full h-full"
+                height="100%"
+                maxWidth="100%"
+                width="100%"
+              />
+              <img
+                [ngStyle]="{
+                  visibility: showSkeleton() ? 'hidden' : 'visible'
+                }"
+                (load)="onLoad()"
+                src="images/self/me-sq.jpg"
+                class="rounded-xl"
+                alt="Me in Norway"
+              />
+            </div>
             <div class="pt-4 sm:pl-4 sm:pt-0">
               My name is Elanna Grossman. I am a full-stack developer, primarily
               focused on Angular and .NET. I most recently worked at
@@ -106,11 +130,16 @@ export default class HomeComponent implements OnInit {
     .filter((post) => post.attributes.published)
     .sort(sortByUpdatedOrOriginalDate)
     .slice(0, 3);
+  public showSkeleton: WritableSignal<boolean> = signal(true);
 
   private metadataService = inject(MetadataService);
 
   ngOnInit(): void {
     this.metadataService.setPageURLMetaTitle(pageTitle.title);
     this.metadataService.updateTags(metaTagList);
+  }
+
+  public onLoad(): void {
+    this.showSkeleton.set(false);
   }
 }

--- a/src/app/pages/index.page.ts
+++ b/src/app/pages/index.page.ts
@@ -71,7 +71,7 @@ export const metaTagList: MetaDefinition[] = [
             class="flex flex-col sm:flex-row justify-evenly items-center pb-4 sm:flex-nowrap"
           >
             <div
-              class="relative flex justify-center rounded-xl max-h-32 sm:max-h-36 max-w-32 sm:max-w-36"
+              class="relative flex justify-center rounded-xl max-h-32 max-w-32 sm:max-h-36 sm:max-w-36"
             >
               <app-skeleton-card
                 *ngIf="showSkeleton()"

--- a/src/app/pages/index.page.ts
+++ b/src/app/pages/index.page.ts
@@ -71,7 +71,7 @@ export const metaTagList: MetaDefinition[] = [
             class="flex flex-col sm:flex-row justify-evenly items-center pb-4 sm:flex-nowrap"
           >
             <div
-              class="relative flex justify-center rounded-xl max-h-32 max-w-32 sm:max-h-36 sm:max-w-36"
+              class="relative flex justify-center rounded-xl max-h-32 max-w-32 !w-fit"
             >
               <app-skeleton-card
                 *ngIf="showSkeleton()"

--- a/src/app/pages/talks/index.page.ts
+++ b/src/app/pages/talks/index.page.ts
@@ -1,4 +1,4 @@
-import { JsonPipe, NgFor, NgIf, NgStyle } from '@angular/common';
+import { NgFor, NgIf, NgStyle } from '@angular/common';
 import {
   Component,
   DestroyRef,
@@ -48,7 +48,7 @@ export const metaTagList: MetaDefinition[] = [
 @Component({
   selector: 'app-talks-index',
   standalone: true,
-  imports: [JsonPipe, NgFor, NgIf, NgStyle, SkeletonCardComponent],
+  imports: [NgFor, NgIf, NgStyle, SkeletonCardComponent],
   template: `
     <div class="md:max-w md:mx-auto md:flex md:flex-col md:items-center">
       <div class="md:w-[48rem] p-4">


### PR DESCRIPTION
# Changes

# Changes

- [x] Use skeleton cards on talk images
- [x] Use skeleton cards on profile picture on about page
- [x] Use skeleton cards on profile picture on homepage
- [x] Improve skeleton card positioning on recent photo albums for mobile

Closes #269.