### PR TITLE
fix(paginator): set `page` value instead of adding query param

### DIFF
--- a/src/app/components/paginator/paginator.component.ts
+++ b/src/app/components/paginator/paginator.component.ts
@@ -138,13 +138,13 @@ export class PaginatorComponent implements OnInit {
 
   private addRouteListener(): void {
     this.route.queryParamMap.subscribe((params) => {
-      const page = params.get('page');
-      if (page) {
-        this.currentPage = parseInt(page, 10);
-        this.pageChanged.emit(this.currentPage);
-      } else {
-        this.changePage(1);
+      let page = params.get('page');
+      if (!page) {
+        // Set page to 1 without triggering query param or navigation
+        page = '1';
       }
+      this.currentPage = parseInt(page, 10);
+      this.pageChanged.emit(this.currentPage);
     });
   }
 


### PR DESCRIPTION
# Changes

- [x] No longer set a page query parameter on the bare `blog` route when it is not present.
- [x] Set the `page` value to `1`.

Closes #273.
