### PR TITLE
feat(app): add alt text to front matter

### DIFF
--- a/src/app/components/blog-card/blog-card.component.ts
+++ b/src/app/components/blog-card/blog-card.component.ts
@@ -32,25 +32,19 @@ import { getMonth } from '@utils/get-month';
     PillComponent,
     ReplaceBrokenImageDirective,
     RouterLink,
-    SkeletonCardComponent
-],
+    SkeletonCardComponent,
+  ],
   template: `
     <div class="py-5 flex flex-col-reverse sm:flex-row">
       <div class="sm:pr-2 sm:max-w grow">
         <div class="flex items-center">
           @if (post?.attributes?.last_updated) {
-            <div
-              class="text-xs pt-1 sm:pt-0"
-              >
+            <div class="text-xs pt-1 sm:pt-0">
               Updated {{ post.attributes.last_updated | date }}
             </div>
           }
           @if (post?.attributes?.date && post?.attributes?.last_updated) {
-            <div
-              class="text-xs pl-2 pt-1 sm:pt-0"
-              >
-              | &nbsp;
-            </div>
+            <div class="text-xs pl-2 pt-1 sm:pt-0">| &nbsp;</div>
           }
           @if (post?.attributes?.date) {
             <div class="text-xs pt-1 sm:pt-0">
@@ -72,56 +66,62 @@ import { getMonth } from '@utils/get-month';
               [label]="post.attributes.category"
               [route]="'/category'"
               [slug]="post.attributes.category"
-              />
+            />
           </div>
         }
       </div>
       @if (post?.attributes?.cover_image) {
-        <div
-          class="relative sm:w-80 sm:min-w-[20rem] sm:h-52"
-          >
+        <div class="relative sm:w-80 sm:min-w-[20rem] sm:h-52">
           @if (showSkeleton()) {
             <app-skeleton-card
               class="rounded-md absolute min-w-full h-full"
               height="100%"
               maxWidth="100%"
               [width]="isSmallScreen ? '' : '320px'"
-              />
+            />
           }
           <a [routerLink]="['/blog', year, month, post.slug]">
             @if (isLCP) {
               <span class="flex aspect-[1/0.65]">
                 <img
                   [src]="post.attributes.cover_image || ''"
-                  [alt]="post.attributes.cover_image_title ?? 'Post Cover Image'"
-                [ngStyle]="{
-                  visibility: showSkeleton() ? 'hidden' : 'visible',
-                }"
+                  [alt]="
+                    (post.attributes.cover_image_alt ||
+                      post.attributes.cover_image_title) ??
+                    'Post Cover Image'
+                  "
+                  [ngStyle]="{
+                    visibility: showSkeleton() ? 'hidden' : 'visible',
+                  }"
                   (load)="onLoad()"
                   appReplaceBrokenImage
                   class="sm:max-w-xs rounded-md w-full h-full object-cover object-center"
                   priority
-                  />
+                />
               </span>
             } @else {
               <span class="flex aspect-[1/0.65]">
                 <img
                   [src]="post.attributes.cover_image || ''"
-                  [alt]="post.attributes.cover_image_title ?? 'Post Cover Image'"
-                [ngStyle]="{
-                  visibility: showSkeleton() ? 'hidden' : 'visible',
-                }"
+                  [alt]="
+                    (post.attributes.cover_image_alt ||
+                      post.attributes.cover_image_title) ??
+                    'Post Cover Image'
+                  "
+                  [ngStyle]="{
+                    visibility: showSkeleton() ? 'hidden' : 'visible',
+                  }"
                   (load)="onLoad()"
                   appReplaceBrokenImage
                   class="sm:max-w-xs rounded-md w-full h-full object-cover object-center"
-                  />
+                />
               </span>
             }
           </a>
         </div>
       }
     </div>
-    `,
+  `,
 })
 export default class BlogCardComponent implements OnInit {
   @Input() post!: ContentFile<BlogPost>;

--- a/src/app/components/photo-album/photo-album.component.ts
+++ b/src/app/components/photo-album/photo-album.component.ts
@@ -18,42 +18,44 @@ import { PhotosetListItem } from '@models/flickr';
             height="100%"
             maxWidth="100%"
             width=""
-            />
+          />
         }
         <a
           [href]="flickr.albumUrl + '/' + photo.id"
           class="flex aspect-[1/0.65]"
           target="_blank"
           rel="noopener"
-          >
+        >
           <img
-          [src]="
-            flickr.albumPhotoUrl +
-            '/' +
-            photo.server +
-            '/' +
-            photo.primary +
-            '_' +
-            photo.secret +
-            '_c.jpg'
-          "
+            [src]="
+              flickr.albumPhotoUrl +
+              '/' +
+              photo.server +
+              '/' +
+              photo.primary +
+              '_' +
+              photo.secret +
+              '_c.jpg'
+            "
             [ngStyle]="{ visibility: showSkeleton() ? 'hidden' : 'visible' }"
             (load)="onLoad()"
-            alt=""
+            [alt]="photo.description._content"
             appReplaceBrokenImage
             class="w-full h-full rounded-md object-cover"
-            />
+          />
           <div
             class="absolute top-0 left-0 right-0 bottom-0 flex flex-col justify-end p-4"
+          >
+            <h2
+              class="text-white text-xl font-bold text-shadow-xs shadow-black"
             >
-            <h2 class="text-white text-xl font-bold text-shadow-xs shadow-black">
               {{ photo.title._content }}
             </h2>
           </div>
         </a>
       </div>
     }
-    `,
+  `,
 })
 export default class PhotoAlbumComponent {
   @Input() public photo!: PhotosetListItem;

--- a/src/app/constants/talks.ts
+++ b/src/app/constants/talks.ts
@@ -16,6 +16,7 @@ export const talks: Talk[] = [
       },
     ],
     imageLink: 'images/other/iwdc_fresno_2020.png',
+    imageAlt: 'The logo for Break It 2020, the IWDC Fresno 2020 convention.',
   },
   {
     title: 'Observables Are Not Promises! A How To',
@@ -32,11 +33,15 @@ export const talks: Talk[] = [
       },
     ],
     imageLink: 'images/other/vdf_fresno_2018.jpg',
+    imageAlt:
+      'The logo for Día de los DevFest, the GDG Valley DevFest 2018 convention.',
   },
   {
     title: 'Verbal and Non-Verbal Workplace Discrimination',
     description: `I was asked to fill in as a last minute speaker at Women Techmakers Fresno International Women's Day 2017 conference. I gave a talk titled Verbal and Non-Verbal Workplace Discrimination, and as a group the audience and I discussed discrimination, how to recognize it, and how to handle it.`,
     date: 'March 19, 2017',
     imageLink: 'images/other/iwdc_fresno_2017.jpg',
+    imageAlt:
+      'The logo for Telling Our Stories the IWDC Fresno 2017 convention.',
   },
 ];

--- a/src/app/models/post.ts
+++ b/src/app/models/post.ts
@@ -4,6 +4,7 @@ export interface BlogPost {
   author?: string;
   category?: Category;
   cover_image?: string;
+  cover_image_alt?: string;
   cover_image_author?: string;
   cover_image_source?: string;
   cover_image_title?: string;

--- a/src/app/models/talk.ts
+++ b/src/app/models/talk.ts
@@ -6,4 +6,5 @@ export interface Talk {
   date?: string;
   urlList?: Navigation[];
   imageLink?: string;
+  imageAlt?: string;
 }

--- a/src/app/pages/blog/[year].[month].[slug].page.ts
+++ b/src/app/pages/blog/[year].[month].[slug].page.ts
@@ -78,7 +78,11 @@ import { splitTagStringIntoTagArray } from '@utils/split-tag-string-into-array';
                   <img
                     appReplaceBrokenImage
                     [ngSrc]="post.attributes.cover_image"
-                    [alt]="post.attributes.cover_image_title"
+                    [alt]="
+                      (post.attributes.cover_image_alt ||
+                        post.attributes.cover_image_title) ??
+                      'Post Cover Image'
+                    "
                     class="w-full max-w-full rounded-md"
                     height="615"
                     width="800"

--- a/src/app/pages/talks/index.page.ts
+++ b/src/app/pages/talks/index.page.ts
@@ -96,7 +96,9 @@ export const metaTagList: MetaDefinition[] = [
                       @if (i === 0) {
                         <img
                           [src]="talk.imageLink"
-                          [alt]="talk.title || 'Talk Cover Image'"
+                          [alt]="
+                            (talk.imageAlt || talk.title) ?? 'Talk Cover Image'
+                          "
                           [ngStyle]="{
                             visibility: showSkeleton() ? 'hidden' : 'visible',
                           }"
@@ -108,7 +110,9 @@ export const metaTagList: MetaDefinition[] = [
                       } @else {
                         <img
                           [src]="talk.imageLink"
-                          [alt]="talk.title || 'Talk Cover Image'"
+                          [alt]="
+                            (talk.imageAlt || talk.title) ?? 'Talk Cover Image'
+                          "
                           [ngStyle]="{
                             visibility: showSkeleton() ? 'hidden' : 'visible',
                           }"

--- a/src/content/posts/a-curated-list-of-angular-resources.md
+++ b/src/content/posts/a-curated-list-of-angular-resources.md
@@ -9,6 +9,7 @@ cover_image: https://live.staticflickr.com/7029/6811030363_456a9347db_c.jpg
 cover_image_author: Elanna Grossman
 cover_image_source: https://www.flickr.com/photos/jadeilyn/6811030363/
 cover_image_title: Sky Lodge view
+cover_image_alt: One of my photos called Sky Lodge view. It depicts a landscape in the Sonoran desert.
 category: development
 tags: development,angular,rxjs
 slug: a-curated-list-of-angular-resources

--- a/src/content/posts/a-curated-list-of-angular-resources.md
+++ b/src/content/posts/a-curated-list-of-angular-resources.md
@@ -122,7 +122,7 @@ Having worked with Angular since mid-2017, I have collected many resources that 
 ### Understanding Hot and Cold Observables
 
 - [Cold vs Hot Observables](https://blog.thoughtram.io/angular/2016/06/16/cold-vs-hot-observables.html)
-- [Netflix vs. Live Broadcast: Understanding Cold and Hot Observables in RxJS 7 ](https://dev.to/md_nafishalam_58b9fca2a5/netflix-vs-live-broadcast-understanding-cold-and-hot-observables-in-rxjs-7-21h9) The original version of the article that I liked seems to be gone but this one does a decent job of using the same metaphors.
+- [Netflix vs. Live Broadcast: Understanding Cold and Hot Observables in RxJS 7](https://dev.to/md_nafishalam_58b9fca2a5/netflix-vs-live-broadcast-understanding-cold-and-hot-observables-in-rxjs-7-21h9) The original version of the article that I liked seems to be gone but this one does a decent job of using the same metaphors.
 - [Visualizing Reactive Streams: Hot and Cold Observables](https://jaredforsyth.com/posts/visualizing-reactive-streams-hot-and-cold/)
 - [Understanding RxJS Multicast Operators](https://medium.com/netanelbasal/understanding-rxjs-multicast-operators-77b3f60af0a2)
 

--- a/src/content/posts/creating-a-multi-control-custom-validator-in-angular.md
+++ b/src/content/posts/creating-a-multi-control-custom-validator-in-angular.md
@@ -8,6 +8,7 @@ cover_image: https://live.staticflickr.com/2504/3760365901_ccbfae1188_c.jpg
 cover_image_author: Elanna Grossman
 cover_image_source: https://flickr.com/photos/jadeilyn/3760365901
 cover_image_title: Sunset
+cover_image_alt: One of my photos called Sunset. It depicts sunset at a lagoon with ducks swimming through the water.
 category: development
 tags: angular,custom validator,form validation,reactive forms
 slug: creating-a-multi-control-custom-validator-in-angular

--- a/src/content/posts/creating-a-multi-control-custom-validator-in-angular.md
+++ b/src/content/posts/creating-a-multi-control-custom-validator-in-angular.md
@@ -196,4 +196,4 @@ Custom validators are easy to make and very powerful. Since they can be made at 
 
 ## Resources
 
-The repository includes [unit tests for the validator](https://github.com/Karvel/angular-password-strength/blob/main/src/app/infrastructure/utils/validators/match-field-validator.spec.ts) to help dial in the desired behavior. [Here](https://github.com/Karvel/angular-password-strength) is the repository on GitHub, and [here](https://stackblitz.com/github/Karvel/angular-password-strength) is a working demo of the code on StackBlitz.
+The repository includes [unit tests for the validator](https://github.com/Karvel/angular-password-strength/blob/main/src/app/infrastructure/utils/validators/match-field-validator.spec.ts) to help dial in the desired behavior. [Here is the repository](https://github.com/Karvel/angular-password-strength) on GitHub, and [here is a working demo](https://stackblitz.com/github/Karvel/angular-password-strength) of the code on StackBlitz.

--- a/src/content/posts/exploring-custom-form-validators-in-angular.md
+++ b/src/content/posts/exploring-custom-form-validators-in-angular.md
@@ -8,6 +8,7 @@ cover_image: https://live.staticflickr.com/5635/30961256076_198998e721_c.jpg
 cover_image_author: Elanna Grossman
 cover_image_source: https://flickr.com/photos/jadeilyn/30961256076/
 cover_image_title: Lonely Road
+cover_image_alt: One of my photos called Lonely Road. It depicts a road through the desert with a Joshua tree nearby.
 category: development
 tags: angular,custom validator,form validation,reactive forms
 slug: exploring-custom-form-validators-in-angular

--- a/src/content/posts/exploring-custom-form-validators-in-angular.md
+++ b/src/content/posts/exploring-custom-form-validators-in-angular.md
@@ -160,7 +160,7 @@ I added the second check of `error.key !== 'required'` here to skip over the req
 
 ## Testing the Validator
 
-It is really easy to write unit tests for these kinds of validators. This way I can write custom logic and feel confident that it does what I expect and that I am handling edge cases. Below are some example test snippets, and the rest are [here](https://github.com/Karvel/angular-password-strength/blob/main/src/app/infrastructure/utils/validators/password-validator.spec.ts):
+It is really easy to write unit tests for these kinds of validators. This way I can write custom logic and feel confident that it does what I expect and that I am handling edge cases. Below are some example test snippets, and [the rest are here](https://github.com/Karvel/angular-password-strength/blob/main/src/app/infrastructure/utils/validators/password-validator.spec.ts):
 
 ```ts copy=true
 it(`should return null if value matches RegEx`, () => {
@@ -195,4 +195,4 @@ Between creating custom validators like this and then [listening to the form sta
 
 ## Resources
 
-The repository includes [unit tests for the validator](https://github.com/Karvel/angular-password-strength/blob/main/src/app/infrastructure/utils/validators/password-validator.spec.ts) to help dial in the desired behavior. [Here](https://github.com/Karvel/angular-password-strength) is the repository on GitHub, and [here](https://stackblitz.com/github/Karvel/angular-password-strength) is a working demo of the code on StackBlitz.
+The repository includes [unit tests for the validator](https://github.com/Karvel/angular-password-strength/blob/main/src/app/infrastructure/utils/validators/password-validator.spec.ts) to help dial in the desired behavior. [Here is the repository](https://github.com/Karvel/angular-password-strength) on GitHub, and [here is a working demo](https://stackblitz.com/github/Karvel/angular-password-strength) of the code on StackBlitz.

--- a/src/content/posts/hello-world.md
+++ b/src/content/posts/hello-world.md
@@ -6,6 +6,7 @@ cover_image: https://live.staticflickr.com/3560/3480913783_36f732956d_z.jpg
 cover_image_author: Elanna Grossman
 cover_image_source: https://www.flickr.com/photos/jadeilyn/3480913783
 cover_image_title: Banana Slug!
+cover_image_alt: One of my photos called Banana Slug! It is an up close shot of a banana slug on the forest floor.
 category: development
 tags: cms, hello world, lithium hosting
 slug: hello-world

--- a/src/content/posts/hirepalooza.md
+++ b/src/content/posts/hirepalooza.md
@@ -6,6 +6,7 @@ canonical_url: https://elanna.me/blog/2015/06/hirepalooza
 cover_image: https://elanna.me/images/upload/hirepalooza.png
 cover_image_author: Hirepalooza
 cover_image_title: Hirepalooza
+cover_image_alt: An image of the Hirepalooza logo, a San Francisco hiring fair that ran until 2015.
 category: miscellaneous
 tags: hirepalooza
 slug: hirepalooza

--- a/src/content/posts/how-i-switched-my-website-to-analog.md
+++ b/src/content/posts/how-i-switched-my-website-to-analog.md
@@ -9,6 +9,7 @@ cover_image: https://live.staticFlickr.com/65535/52270210933_b2f9572e2f_c.jpg
 cover_image_author: Elanna Grossman
 cover_image_source: https://www.Flickr.com/photos/jadeilyn/52270210933
 cover_image_title: Light Towers
+cover_image_alt: One of my photos called Light Towers. It depicts an art installation with fiber optic lights.
 category: development
 tags: development,angular,analogjs, wordpress,markdown,rxjs
 slug: how-i-switched-my-website-to-analog

--- a/src/content/posts/i-am-giving-a-code-talk-about-observables.md
+++ b/src/content/posts/i-am-giving-a-code-talk-about-observables.md
@@ -21,4 +21,4 @@ Here is the talk description:
 
 An exploration of observables, the headlining feature of RxJS and primary asynchronous structure in Angular. We will look at common use cases and pitfalls, both client and server-side, and discuss how to move away from promise-based data flow.
 
-The GitHub repo for the Angular client is [here](https://github.com/Karvel/angular-observable-examples-app). The API repo is [here](https://github.com/Karvel/angular-observables-api). The link to the slide deck is [here](https://drive.google.com/open?id=1vothDZHzTdMA1mM6F2R2XMGWpgZqlUOcmNE74edf_1Y).
+The [GitHub repo for the Angular client is here](https://github.com/Karvel/angular-observable-examples-app). The [API repo is here](https://github.com/Karvel/angular-observables-api). The [link to the slide deck is here](https://drive.google.com/open?id=1vothDZHzTdMA1mM6F2R2XMGWpgZqlUOcmNE74edf_1Y).

--- a/src/content/posts/i-am-giving-a-code-talk-about-observables.md
+++ b/src/content/posts/i-am-giving-a-code-talk-about-observables.md
@@ -8,6 +8,7 @@ cover_image: https://live.staticflickr.com/5649/25379653969_84c364ab37_c.jpg
 cover_image_author: Elanna Grossman
 cover_image_source: https://www.flickr.com/photos/jadeilyn/25379653969
 cover_image_title: Fireworks
+cover_image_alt: One of my photos called Fireworks. It shows fireworks from a Fourth of July event.
 category: development
 tags: 	angular, developer group, google, rxjs, valley devfest
 slug: i-am-giving-a-code-talk-about-observables

--- a/src/content/posts/its-about-time.md
+++ b/src/content/posts/its-about-time.md
@@ -7,6 +7,7 @@ cover_image: https://live.staticflickr.com/7063/13942708096_718b6dadac_h.jpg
 cover_image_author: Elanna Grossman
 cover_image_source: https://www.flickr.com/photos/jadeilyn/13942708096
 cover_image_title: Saguaro Silhouette
+cover_image_alt: One of my photos called Saguaro Silhouette. It depicts a sahuaro cactus silhouetted by the sun.
 category: miscellaneous
 slug: its-about-time
 published: true

--- a/src/content/posts/iwdc-2020-fresno-imposter-syndrome.md
+++ b/src/content/posts/iwdc-2020-fresno-imposter-syndrome.md
@@ -12,6 +12,6 @@ slug: iwdc-2020-fresno-imposter-syndrome
 published: true
 ---
 
-I gave another talk! This time it was at IWDC Fresno 2020. The talk is titled Imposter Syndrome: No One Belongs Here More Than You!, and the content is available [here](https://github.com/Karvel/iwdc-2020-imposter-syndrome-talk).
+I gave another talk! This time it was at IWDC Fresno 2020. The talk is titled Imposter Syndrome: No One Belongs Here More Than You!, and [the content is available here](https://github.com/Karvel/iwdc-2020-imposter-syndrome-talk).
 
 It has been over two years since I gave my [last talk](https://elanna.me/blog/2018/10/i-am-giving-a-code-talk-about-observables/) at a conference.

--- a/src/content/posts/iwdc-2020-fresno-imposter-syndrome.md
+++ b/src/content/posts/iwdc-2020-fresno-imposter-syndrome.md
@@ -5,6 +5,7 @@ description: I gave another talk! This time it was at IWDC Fresno 2020. The talk
 canonical_url: https://elanna.me/blog/2020/03/iwdc-2020-fresno-imposter-syndrome
 cover_image: https://elanna.me/images/other/iwdc_fresno_2020.png
 cover_image_title: IWDC Fresno 2020
+cover_image_alt: The logo for Break It 2020, the IWDC Fresno 2020 convention.
 category: development
 tags: imposter syndrome,iwdc
 slug: iwdc-2020-fresno-imposter-syndrome

--- a/src/content/posts/making-a-localeuppercasepipe-for-angular.md
+++ b/src/content/posts/making-a-localeuppercasepipe-for-angular.md
@@ -86,4 +86,4 @@ And here is the pipe with a locale argument:
 
 The repository includes [unit tests for the pipe](https://github.com/Karvel/angular-locale-uppercase-pipe/blob/development/src/app/infrastructure/shared/pipes/locale-upper-case.pipe.spec.ts) to help dial in the desired behavior, and shows [multiple examples](https://github.com/Karvel/angular-locale-uppercase-pipe/blob/development/src/app/features/sandbox/test/test.component.html) of the pipe being used.
 
-[Here](https://github.com/Karvel/angular-locale-uppercase-pipe) is the repository on GitHub, and [here](https://stackblitz.com/github/Karvel/angular-locale-uppercase-pipe) is a working demo of the code on StackBlitz.
+[Here is the repository](https://github.com/Karvel/angular-locale-uppercase-pipe) on GitHub, and [here is a working demo](https://stackblitz.com/github/Karvel/angular-locale-uppercase-pipe) of the code on StackBlitz.

--- a/src/content/posts/making-a-localeuppercasepipe-for-angular.md
+++ b/src/content/posts/making-a-localeuppercasepipe-for-angular.md
@@ -8,6 +8,7 @@ cover_image: https://live.staticflickr.com/2262/2290027938_268e2f34c4_z.jpg
 cover_image_author: Elanna Grossman
 cover_image_source: https://www.flickr.com/photos/jadeilyn/2290027938/
 cover_image_title: Métro graffiti
+cover_image_alt: One of my photos called Métro graffiti, showing graffiti on the walls of a métro stairwell in Paris.
 category: development
 tags: angular,angular pipe,toLocaleUpperCase, pipe
 slug: making-a-localeuppercasepipe-for-angular

--- a/src/content/posts/making-a-password-strength-component-in-angular.md
+++ b/src/content/posts/making-a-password-strength-component-in-angular.md
@@ -8,6 +8,7 @@ cover_image: https://live.staticflickr.com/3672/10356922586_7a62f75bfb_c.jpg
 cover_image_author: Elanna Grossman
 cover_image_source: https://flickr.com/photos/jadeilyn/10356922586
 cover_image_title: Western Diamond-backed Rattlesnake
+cover_image_alt: One of my photos called Western Diamond-backed Rattlesnake, showing a rattlesnake at a zoo.
 category: development
 tags: angular,reactive forms,rxjs
 slug: making-a-password-strength-component-in-angular

--- a/src/content/posts/making-a-password-strength-component-in-angular.md
+++ b/src/content/posts/making-a-password-strength-component-in-angular.md
@@ -215,4 +215,4 @@ I made this as a simple tutorial example. If I were to use this in production, I
 
 ## Resources
 
-The repository includes [unit tests for the indicator controls](https://github.com/Karvel/angular-password-strength/blob/main/src/app/infrastructure/shared/components/password-strength/password-strength.component.spec.ts) to help dial in the desired behavior. [Here](https://github.com/Karvel/angular-password-strength) is the repository on GitHub, and [here](https://stackblitz.com/github/Karvel/angular-password-strength) is a working demo of the code on StackBlitz.
+The repository includes [unit tests for the indicator controls](https://github.com/Karvel/angular-password-strength/blob/main/src/app/infrastructure/shared/components/password-strength/password-strength.component.spec.ts) to help dial in the desired behavior. [Here is the repository](https://github.com/Karvel/angular-password-strength) on GitHub, and [here is a working demo](https://stackblitz.com/github/Karvel/angular-password-strength) of the code on StackBlitz.

--- a/src/content/posts/recommended-development-tools-in-linux-macos-and-windows.md
+++ b/src/content/posts/recommended-development-tools-in-linux-macos-and-windows.md
@@ -9,6 +9,7 @@ cover_image: https://live.staticflickr.com/2458/21245815482_6431167871_c.jpg
 cover_image_author: Elanna Grossman
 cover_image_source: https://flickr.com/photos/jadeilyn/21245815482/
 cover_image_title: Kendrick Peak
+cover_image_alt: One of my photos called Kendrick Peak. It depicts a snow-covered peak in Flagstaff, Arizona.
 category: development
 tags: development,codeeditor,git,ide
 slug: recommended-development-tools-in-linux-macos-and-windows

--- a/src/content/posts/recommended-development-tools-in-linux-macos-and-windows.md
+++ b/src/content/posts/recommended-development-tools-in-linux-macos-and-windows.md
@@ -59,7 +59,7 @@ My personal computer is a desktop with system drives for both Linux and Windows 
   - Linux
   - MacOS
   - Windows
-  - I listed my recommended extensions [here](https://elanna.me/blog/2023/01/recommended-vs-code-extensions/).
+  - I listed [my recommended extensions here](https://elanna.me/blog/2023/01/recommended-vs-code-extensions/).
 
 ### Git Client
 

--- a/src/content/posts/recommended-vs-code-extensions.md
+++ b/src/content/posts/recommended-vs-code-extensions.md
@@ -8,6 +8,7 @@ cover_image: https://live.staticflickr.com/2458/3776870085_fe285e9698_c.jpg
 cover_image_author: Elanna Grossman
 cover_image_source: https://flickr.com/photos/jadeilyn/3776870085
 cover_image_title: So cool
+cover_image_alt: One of my photos called So cool. It depicts pelicans flying over a beach in Santa Cruz, California.
 category: development
 tags: development,linux,macos,osx
 slug: recommended-vs-code-extensions

--- a/src/content/posts/time-for-a-change-switching-to-analog.md
+++ b/src/content/posts/time-for-a-change-switching-to-analog.md
@@ -8,6 +8,7 @@ cover_image: https://live.staticflickr.com/65535/52270701195_32302b3ede_c.jpg
 cover_image_author: Elanna Grossman
 cover_image_source: https://www.flickr.com/photos/jadeilyn/52270701195
 cover_image_title: Light House Fog
+cover_image_alt: One of my photos called Light House Fog. It a lighthouse in fog in San Simeon, California.
 category: development
 tags: development,angular,analogjs, wordpress,markdown
 slug: time-for-a-change-switching-to-analog


### PR DESCRIPTION
# Changes

- [x] Add `cover_image_alt` property
- [x] Wire up to cover image linking
- [x] Wire up to photo album images
- [x] Wire up to talk page images
- [x] Update alt text fallback logic
- [x] Add alt text for posts and talks
- [x] Improve link text for accessibility

Closes #324.